### PR TITLE
Fixed build when using MSVC compiler

### DIFF
--- a/include/popl.hpp
+++ b/include/popl.hpp
@@ -19,6 +19,7 @@
 
 #define NOMINMAX
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <iostream>


### PR DESCRIPTION
I came across a problem where `popl` refused to compile under MSVC because `std:max()` and `std::min()` require `<algorithm>` header.