### PR TITLE
Add const-correctness to argv

### DIFF
--- a/include/popl.hpp
+++ b/include/popl.hpp
@@ -210,7 +210,7 @@ public:
 	template<typename T, typename... Ts>
 	std::shared_ptr<T> add(Ts&&... params);
 
-	void parse(int argc, char **argv);
+	void parse(int argc, const char * const * argv);
 	std::string help(const Visibility& max_visibility = Visibility::normal) const;
 	std::string description() const;
 	const std::vector<Option_ptr>& options() const;
@@ -691,7 +691,7 @@ inline std::shared_ptr<T> OptionParser::get_option(char short_opt) const
 }
 
 
-inline void OptionParser::parse(int argc, char **argv)
+inline void OptionParser::parse(int argc, const char * const * argv)
 {
 	unknown_options_.clear();
 	non_option_args_.clear();


### PR DESCRIPTION
Hallo

In our project, we use some wrappers around boost_program_options and have tests for them, like that:

```c++
TEST( config_parse,  Pass_Valid_Args_2)
{
    const uint64 mandatory_int_value = 356;
    const std::string mandatory_string_value{ "run_test.elf"};

    const char* argv[] =
    {
        "mipt-mips",
        "-b", "run_test.elf",
        "-n", "356",
        "-d"
    };
    const int argc = countof(argv);

    // should not throw any exceptions
    ASSERT_NO_THROW( config::handleArgs( argc, argv));

    ASSERT_EQ( config::uint64_config, mandatory_int_value);
    ASSERT_FALSE( mandatory_string_value.compare( config::string_config));
    ASSERT_EQ( config::bool_config_1, true);
    ASSERT_EQ( config::bool_config_2, false);
}
```

I decided to switch to Popl, as it is more portable than Boost, has no RTTI requirements, has less weight etc. In order to continue to use these tests, I had to add const-correctness to Popl, as I removing it from array initialization is forbidden by C++ standard:

```bash
unit_test.cpp:85:5: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
```

I find that change quite useful, so I open a pull request.