### PR TITLE
Decorate operator<< with "inline" to silence unused functions warning

### DIFF
--- a/include/popl.hpp
+++ b/include/popl.hpp
@@ -842,10 +842,9 @@ inline std::string OptionParser::help(const Visibility& max_visibility) const
 
 
 
-static std::ostream& operator<<(std::ostream& out, const OptionParser& op)
+static inline std::ostream& operator<<(std::ostream& out, const OptionParser& op)
 {
-	out << op.help();
-	return out;
+	return out << op.help();
 }
 
 


### PR DESCRIPTION
If OptionsParser is not printed in the translation unit whereas popl.hpp file is included, GCC will consider operator<< as unused function and emit a warning. To prevent this, we use "static inline" instead of "static", claiming that function is header-function and may be unused in the code which includes that header.