### PR TITLE
Prevent double definition of NOMINMAX

### DIFF
--- a/include/popl.hpp
+++ b/include/popl.hpp
@@ -17,7 +17,9 @@
 #ifndef POPL_HPP
 #define POPL_HPP
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif // NOMINMAX
 
 #include <cstdio>
 #include <cstring>


### PR DESCRIPTION
The macro is defined by MinGW already; C:/msys64/mingw32/include/c++/7.3.0/i686-w64-mingw32/bits/os_defines.h:45:0: note: this is the location of the previous definition