### PR TITLE
Add 'override' qualifier to Value::get_default() method

### DIFF
--- a/include/popl.hpp
+++ b/include/popl.hpp
@@ -116,7 +116,7 @@ public:
 	void set_default(const T& value);
 	bool has_default() const;
 	T get_default() const;
-	bool get_default(std::ostream& out) const;
+	bool get_default(std::ostream& out) const override;
 
 	Argument argument_type() const override;
 


### PR DESCRIPTION
Clang demands the qualifier if -Wall -Wextra options are enabled