### PR TITLE
Add fixes proposed by Clang-Tidy

### DIFF
--- a/include/popl.hpp
+++ b/include/popl.hpp
@@ -67,6 +67,10 @@ friend class OptionParser;
 public:
 	Option(const std::string& short_option, const std::string& long_option, std::string description);
 	virtual ~Option() = default;
+	Option(const Option&) = default;
+	Option(Option&&) = default;
+	Option& operator=(const Option&) = default;
+	Option& operator=(Option&&) = default;
 
 	char short_option() const;
 	std::string long_option() const;
@@ -126,7 +130,7 @@ protected:
 
 	virtual void update_reference();
 	virtual void add_value(const T& value);
-	virtual void clear() override;
+	void clear() override;
 
 	T* assign_to_;
 	std::vector<T> values_;
@@ -679,9 +683,7 @@ inline void OptionParser::parse(int argc, const char * const argv[])
 		{
 			///from here on only non opt args
 			for (int m=n+1; m<argc; ++m)
-				non_option_args_.push_back(argv[m]);
-
-			break;
+				non_option_args_.emplace_back(argv[m]);
 		}
 		else if (arg.find("--") == 0)
 		{
@@ -717,7 +719,7 @@ inline void OptionParser::parse(int argc, const char * const argv[])
 			else
 				unknown_options_.push_back(arg);
 		}
-		else if (arg.find("-") == 0)
+		else if (arg.find('-') == 0)
 		{
 			/// short option arg
 			std::string opt = arg.substr(1);


### PR DESCRIPTION
I configured Clang-Tidy for my project and dislikes some POPL code.
1. class Option should imply the Rule of Five, as it has an explicit dtor.
2. `virtual` qualifier is redundant if there is `override` qualifier
3. `emplace_back` should be used instead of `push_back` to bypass temporary `std::string` object
4. `break` before `else` is redundant 
5. `std::string::find(char s)` is more efficient than `std::string::find(const char* s)`