### PR TITLE
Make Value::value non-virtual

### DIFF
--- a/include/popl.hpp
+++ b/include/popl.hpp
@@ -115,7 +115,7 @@ public:
 	void assign_to(T* var);
 
 	void set_value(const T& value);
-	virtual T value(size_t idx = 0) const;
+	T value(size_t idx = 0) const;
 
 	void set_default(const T& value);
 	bool has_default() const;


### PR DESCRIPTION
It is not overridden by any derived class, while having virtual method with default arguments is a potential vulnerability