### PR TITLE
Restore start_index option

### DIFF
--- a/include/popl.hpp
+++ b/include/popl.hpp
@@ -336,7 +336,8 @@ public:
     /// Parse the command line into the added Options
     /// @param argc command line argument count
     /// @param argv command line arguments
-    void parse(int argc, const char* const argv[]);
+    /// @param start_index index of starting argument
+    void parse(int argc, const char * const argv[], int start_index = 1);
 
     /// Produce a help message
     /// @param max_attribute show options up to this level (optional, advanced, expert)
@@ -987,14 +988,14 @@ inline void OptionParser::parse(const std::string& ini_filename)
     }
 }
 
-inline void OptionParser::parse(int argc, const char* const argv[])
+inline void OptionParser::parse(int argc, const char* const argv[], int start_index)
 {
     unknown_options_.clear();
     non_option_args_.clear();
     for (auto& opt : options_)
         opt->clear();
 
-    for (int n = 1; n < argc; ++n)
+    for (int n = start_index; n < argc; ++n)
     {
         const std::string arg(argv[n]);
         if (arg == "--")

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -54,3 +54,16 @@ TEST_CASE("config file")
     }
 }
 
+TEST_CASE("start index")
+{
+    OptionParser op("Allowed options");
+    auto help_option = op.add<Switch>("h", "help", "produce help message");
+    auto int_option = op.add<Value<int>>("i", "int", "test for int value", 42);
+    std::vector<const char*> args = {"popl", "-h", "--", "-i", "43"};
+
+    op.parse(args.size(), args.data(), 3);
+    REQUIRE(help_option->count() == 0);
+    REQUIRE(int_option->is_set());
+    REQUIRE(int_option->count() == 1);
+    REQUIRE(int_option->value() == 43);
+}


### PR DESCRIPTION
Usual case for emulation programs, like sde or gdb, is to pass first
arguments to the emulator, and let the guest application handle latter
arguments. To support this behavior, we introduce an option to choose
index of the first argument to be handled by POPL. By default it is 1,
as it is usually corresponds to the binary name.

Looks like the option was dropped during tab2space conversion